### PR TITLE
Update time_entry_patch to not break Work Time

### DIFF
--- a/lib/contracts/patches/time_entry_patch.rb
+++ b/lib/contracts/patches/time_entry_patch.rb
@@ -26,7 +26,7 @@ module Contracts
         protected
         def time_not_exceed_contract
           return if hours.blank?
-          return if contract.is_fixed_price
+          return if contract && contract.is_fixed_price
           previous_hours = (hours_was != nil) ? hours_was : 0 
 
           if contract_id != nil
@@ -47,7 +47,7 @@ module Contracts
         # is enabled and the hours exceed the current contract.
         private
         def create_next_contract
-          return if contract.is_fixed_price
+          return if contract && contract.is_fixed_price
           previous_hours = (hours_was != nil) ? hours_was : 0
           if Setting.plugin_contracts['automatic_contract_creation'] && hours > (contract.hours_remaining + previous_hours)
             new_contract = Contract.new


### PR DESCRIPTION
time_entry_patch was throwing exceptions for contract being a nil object when using redmine contracts plugin together with Redmine Work Time plugin (http://www.redmine.org/plugins/redmine_work_time)